### PR TITLE
Removed file extension from filename

### DIFF
--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -46,13 +46,14 @@ class ResponseProcessor:
                               e=str(e))
             raise BadMessageError
 
-        filename = decrypted_json.get('filename')
+        file_with_extension = decrypted_json.get('filename')
         file = standard_b64decode(decrypted_json.get('file').encode('UTF8'))
+        filename = file_with_extension.split('.')[0]
 
         collex_id = os.getenv('COLLEX_ID')
 
         files = {'file':
-                 (filename,
+                 (file_with_extension,
                   file,
                   'application/vnd.' +
                   'openxmlformats-officedocument.spreadsheetml.sheet',
@@ -65,7 +66,7 @@ class ResponseProcessor:
             url = upload_url.format(collex_id, filename)
             self.logger.info('Posting files to ras',
                              ex_id=collex_id,
-                             filename=filename,
+                             filename=file_with_extension,
                              url=url)
             res = session.post(url, auth=Config.BASIC_AUTH, files=files)
             self.logger.info("Response", text=res.text)


### PR DESCRIPTION
# Motivation and Context
When we are uploading BRES collection instruments through the rabbit adaptor service (ras-rabbit-adaptor-service) we are ended up with the extension in the collection instrument table (ci.business table) This then will fail validation on a collection exercise execution. 

# What has changed
- File extension is now removed from the filename

# How to test?
- Build a new image using `docker build -t sdcplatform/ras-rabbit-adaptor-service`
- Put a collection instrument into an ftp folder in your Documents
- Run `docker-compose up -d` on [sdc-ci-compose-upload](https://github.com/ONSdigital/sdc-ci-upload-compose) 
- File should be uploaded correctly to the collection-instrument service
- In the `ci.business ` table there should be a ru_ref without the extension on the name. 

# Links
[Trello](https://trello.com/c/aAFpeSsN/358-remove-filename-extension-from-bres-collection-instrument-upload-s)